### PR TITLE
fix(assets): use `replaceAll`

### DIFF
--- a/assets/folderIconfont.ejs
+++ b/assets/folderIconfont.ejs
@@ -1,3 +1,3 @@
 <% _.each(glyphs, function(glyph) { %>
-export * as folder_<%= glyph.name.replace('-', '_') %> from 'data-text:./<%= glyph.name %>.svg';
+export * as folder_<%= glyph.name.replaceAll('-', '_') %> from 'data-text:./<%= glyph.name %>.svg';
 <% }); %>

--- a/assets/iconfont.ejs
+++ b/assets/iconfont.ejs
@@ -1,3 +1,3 @@
 <% _.each(glyphs, function(glyph) { %>
-export * as file_<%= glyph.name.replace('-', '_') %> from 'data-text:./<%= glyph.name %>.svg';
+export * as file_<%= glyph.name.replaceAll('-', '_') %> from 'data-text:./<%= glyph.name %>.svg';
 <% }); %>


### PR DESCRIPTION
When updating the `iconGenerator` submodule, I noticed there were icons that used two hyphens, which isn't caught by `.replace` (and gives you a silly error like `expected 'from' got '-'` without any path to the source from plasmo). `replaceAll` is available since Node 15.